### PR TITLE
Include license file in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,4 @@ universal=1
 
 [metadata]
 description-file = README.md
+license_file = LICENSE.txt


### PR DESCRIPTION
The MIT license requires all copies of the software include the license