### PR TITLE
bump widgets version for jlab 1.0, pull version from package.json

### DIFF
--- a/js/lib/version.ts
+++ b/js/lib/version.ts
@@ -9,4 +9,6 @@
  * Update this value when attributes are added/removed from
  * your models, or serialized format changes.
  */
-export const JUPYTER_EXTENSION_VERSION = '1.0.7';
+var pkg_json = require("../package.json");
+
+export const JUPYTER_EXTENSION_VERSION = pkg_json.version;

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -5,16 +5,16 @@
   "requires": true,
   "dependencies": {
     "@jupyter-widgets/base": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@jupyter-widgets/base/-/base-1.2.2.tgz",
-      "integrity": "sha512-i92lNYZEwLJuUazElCUJiDDXXeFDD5m5c7Cqgir4tTG0gnlAWORdNvhTYhKkHdtFs837ILlLHQLXA9Q4oFc6Fw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@jupyter-widgets/base/-/base-2.0.1.tgz",
+      "integrity": "sha512-jRNeQzvEf6MMGUaEPfBzgZ+IT4XOInpw8Ef+CunNUmUCiQZ8WfNpFR671S0Vu3xO6yGKMTU2QPdk8/aCsJRw9w==",
       "requires": {
-        "@jupyterlab/services": "^1.0.1 || ^2.0.0 || ^3.0.0",
+        "@jupyterlab/services": "^4.0.0",
         "@phosphor/coreutils": "^1.2.0",
         "@phosphor/messaging": "^1.2.1",
         "@phosphor/widgets": "^1.3.0",
-        "@types/backbone": "^1.3.33",
-        "@types/lodash": "^4.14.66",
+        "@types/backbone": "^1.4.1",
+        "@types/lodash": "^4.14.134",
         "backbone": "1.2.3",
         "base64-js": "^1.2.1",
         "jquery": "^3.1.1",
@@ -22,157 +22,171 @@
       }
     },
     "@jupyterlab/coreutils": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-2.2.1.tgz",
-      "integrity": "sha512-XkGMBXqEAnENC4fK/L3uEqqxyNUtf4TI/1XNDln7d5VOPHQJSBTbYlBAZ0AQotn2qbs4WqmV6icxje2ITVedqQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz",
+      "integrity": "sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2",
-        "ajv": "~5.1.6",
-        "comment-json": "^1.1.3",
+        "@phosphor/commands": "^1.6.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/properties": "^1.1.3",
+        "@phosphor/signaling": "^1.2.3",
+        "ajv": "^6.5.5",
+        "json5": "^2.1.0",
         "minimist": "~1.2.0",
-        "moment": "~2.21.0",
+        "moment": "^2.24.0",
         "path-posix": "~1.0.0",
         "url-parse": "~1.4.3"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
       }
     },
     "@jupyterlab/observables": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.1.1.tgz",
-      "integrity": "sha512-PzmJ/jF5fWzHCvjPAWBi3YjtHRAF0bwyjpd8W8aJt64TzhEZh0se8xCNGOURzD+8TxOsTF9JpQ9wIDBr4V226Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.3.0.tgz",
+      "integrity": "sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/signaling": "^1.2.2"
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/messaging": "^1.2.3",
+        "@phosphor/signaling": "^1.2.3"
       }
     },
     "@jupyterlab/services": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-3.2.1.tgz",
-      "integrity": "sha512-zCMruGGYxTe427ESK4YUO1V/liFOFYpebYPRsJ+j9CFdV+Hm760+nx4pFX6N6Z9TbS+5cs8BgZ+ebm8unRZrJg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.1.0.tgz",
+      "integrity": "sha512-5C53UdpLP5rLLpN8zEfzole5PNakNWSDCitd4ysqZiWihV4lpNNXKmqn5seHrcvevUkrDM9pyNcg00djGkpbvw==",
       "requires": {
-        "@jupyterlab/coreutils": "^2.2.1",
-        "@jupyterlab/observables": "^2.1.1",
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2"
+        "@jupyterlab/coreutils": "^3.1.0",
+        "@jupyterlab/observables": "^2.3.0",
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/signaling": "^1.2.3",
+        "node-fetch": "^2.6.0",
+        "ws": "^7.0.0"
       }
     },
     "@phosphor/algorithm": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.1.2.tgz",
-      "integrity": "sha1-/R3pEEyafzTpKGRYbd8ufy53eeg="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
+      "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
     },
     "@phosphor/collections": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.1.2.tgz",
-      "integrity": "sha1-xMC4uREpkF+zap8kPy273kYtq40=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
+      "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2"
+        "@phosphor/algorithm": "^1.2.0"
       }
     },
     "@phosphor/commands": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/commands/-/commands-1.6.1.tgz",
-      "integrity": "sha512-iRgn7QX64e0VwZ91KFo964a/LVpw9XtiYIYtpymEyKY757NXvx6ZZMt1CqKfntoDcSZJeVte4eV8jJWhZoVlDA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/commands/-/commands-1.7.0.tgz",
+      "integrity": "sha512-2tkij4fiU0WcnUiY0H0kX9mQhdJms5X6s+X9Uzx5P+KJZm0B83VIC1OEb1YYDYh8ar+LMr0dBnM5ljvZbptUXw==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/domutils": "^1.1.2",
-        "@phosphor/keyboard": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2"
+        "@phosphor/algorithm": "^1.2.0",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.3.0",
+        "@phosphor/domutils": "^1.1.3",
+        "@phosphor/keyboard": "^1.1.3",
+        "@phosphor/signaling": "^1.3.0"
       }
     },
     "@phosphor/coreutils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@phosphor/coreutils/-/coreutils-1.3.0.tgz",
-      "integrity": "sha1-YyktOBwBLFqw0Blug87YKbfgSkI="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@phosphor/coreutils/-/coreutils-1.3.1.tgz",
+      "integrity": "sha512-9OHCn8LYRcPU/sbHm5v7viCA16Uev3gbdkwqoQqlV+EiauDHl70jmeL7XVDXdigl66Dz0LI11C99XOxp+s3zOA=="
     },
     "@phosphor/disposable": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.1.2.tgz",
-      "integrity": "sha1-oZLdai5sadXQnTns8zTauTd4Bg4=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.3.0.tgz",
+      "integrity": "sha512-wHQov7HoS20mU6yuEz5ZMPhfxHdcxGovjPoid0QwccUEOm33UBkWlxaJGm9ONycezIX8je7ZuPOf/gf7JI6Dlg==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2"
+        "@phosphor/algorithm": "^1.2.0",
+        "@phosphor/signaling": "^1.3.0"
       }
     },
     "@phosphor/domutils": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/domutils/-/domutils-1.1.2.tgz",
-      "integrity": "sha1-4u/rBS85jEK5O4npurJq8VzABRQ="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@phosphor/domutils/-/domutils-1.1.3.tgz",
+      "integrity": "sha512-5CtLAhURQXXHhNXfQydDk/luG1cDVnhlu/qw7gz8/9pht0KXIAmNg/M0LKxx2oJ9+YMNCLVWxAnHAU0yrDpWSA=="
     },
     "@phosphor/dragdrop": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@phosphor/dragdrop/-/dragdrop-1.3.0.tgz",
-      "integrity": "sha1-fOatOdbKIW1ipW94EE0Cp3rmcwc=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/dragdrop/-/dragdrop-1.4.0.tgz",
+      "integrity": "sha512-JqmDAKczviUe7NEkiDf/A6H2glgVmHAREip8dGBli4lvV+CQqPFyl4Xm7XCnR9qiEqNrP+0SfwPpywNa0me3nQ==",
       "requires": {
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2"
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.3.0"
       }
     },
     "@phosphor/keyboard": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/keyboard/-/keyboard-1.1.2.tgz",
-      "integrity": "sha1-PjIjRFF2QkCpjhSANNWoeXQi3R8="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@phosphor/keyboard/-/keyboard-1.1.3.tgz",
+      "integrity": "sha512-dzxC/PyHiD6mXaESRy6PZTd9JeK+diwG1pyngkyUf127IXOEzubTIbu52VSdpGBklszu33ws05BAGDa4oBE4mQ=="
     },
     "@phosphor/messaging": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.2.2.tgz",
-      "integrity": "sha1-fYlt3TeXuUo0dwje0T2leD23XBQ=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
+      "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/collections": "^1.1.2"
+        "@phosphor/algorithm": "^1.2.0",
+        "@phosphor/collections": "^1.2.0"
       }
     },
     "@phosphor/properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/properties/-/properties-1.1.2.tgz",
-      "integrity": "sha1-eMx37/RSg52gIlXeSOgUlGzAmig="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@phosphor/properties/-/properties-1.1.3.tgz",
+      "integrity": "sha512-GiglqzU77s6+tFVt6zPq9uuyu/PLQPFcqZt914ZhJ4cN/7yNI/SLyMzpYZ56IRMXvzK9TUgbRna6URE3XAwFUg=="
     },
     "@phosphor/signaling": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.2.2.tgz",
-      "integrity": "sha1-P8+Xyojji/s1f+j+a/dRM0elFKk=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.3.0.tgz",
+      "integrity": "sha512-ZbG2Mof4LGSkaEuDicqA2o2TKu3i5zanjr2GkevI/82aKBD7cI1NGLGT55HZwtE87/gOF4FIM3d3DeyrFDMjMQ==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2"
+        "@phosphor/algorithm": "^1.2.0"
       }
     },
     "@phosphor/virtualdom": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/virtualdom/-/virtualdom-1.1.2.tgz",
-      "integrity": "sha1-zlXIbu8x5dDiax3JbqMr1oRFj0E=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/virtualdom/-/virtualdom-1.2.0.tgz",
+      "integrity": "sha512-L9mKNhK2XtVjzjuHLG2uYuepSz8uPyu6vhF4EgCP0rt0TiLYaZeHwuNu3XeFbul9DMOn49eBpye/tfQVd4Ks+w==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2"
+        "@phosphor/algorithm": "^1.2.0"
       }
     },
     "@phosphor/widgets": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@phosphor/widgets/-/widgets-1.6.0.tgz",
-      "integrity": "sha512-HqVckVF8rJ15ss0Zf/q0AJ69ZKNFOO26qtNKAdGZ9SmmkSMf73X6pB0R3Fj5+Y4Sjl8ezIIKG6mXj+DxOofnwA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/widgets/-/widgets-1.9.0.tgz",
+      "integrity": "sha512-Op6H0lI7MlHAs+htzy+6fL+x3TxG0N024RGsdIYkaNKyeSw6b7ZUXcd7mKCeabWPoTwiMCx3kiLTvExmNSYgwA==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/commands": "^1.5.0",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/domutils": "^1.1.2",
-        "@phosphor/dragdrop": "^1.3.0",
-        "@phosphor/keyboard": "^1.1.2",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/properties": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/virtualdom": "^1.1.2"
+        "@phosphor/algorithm": "^1.2.0",
+        "@phosphor/commands": "^1.7.0",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.3.0",
+        "@phosphor/domutils": "^1.1.3",
+        "@phosphor/dragdrop": "^1.4.0",
+        "@phosphor/keyboard": "^1.1.3",
+        "@phosphor/messaging": "^1.3.0",
+        "@phosphor/properties": "^1.1.3",
+        "@phosphor/signaling": "^1.3.0",
+        "@phosphor/virtualdom": "^1.2.0"
       }
     },
     "@types/backbone": {
-      "version": "1.3.43",
-      "resolved": "https://registry.npmjs.org/@types/backbone/-/backbone-1.3.43.tgz",
-      "integrity": "sha512-TAoXvN4neAw2rEOQN8mg0Y0oLYgmPoCWtcMW4Rk19vJahcYueK0Yrf/2TZKWM81K/E1QpHKKyhITaU9LwXAATA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@types/backbone/-/backbone-1.4.1.tgz",
+      "integrity": "sha512-KYfGuQy4d2vvYXbn0uHFZ6brFLndatTMomxBlljpbWf4kFpA3BG/6LA3ec+J9iredrX6eAVI7sm9SVAvwiIM6g==",
       "requires": {
         "@types/jquery": "*",
         "@types/underscore": "*"
@@ -184,17 +198,17 @@
       "integrity": "sha512-ZiY4j3iJvAdOwzwW24WjlZbUNvqOsnPAMfPBmdXqxj3uKJbrzBlRrdGl5uC89pZpFs9Dc92E81KcwG2uEgkIZA=="
     },
     "@types/jquery": {
-      "version": "3.3.22",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.22.tgz",
-      "integrity": "sha512-a4JDcIhJhHYnoWCkG3xT2CZxXZeA92JeREESorg0DMQ3ZsjuKF48h7XK4l5Gl2GRa/ItGRpKMT0pyK88yRgqXQ==",
+      "version": "3.3.31",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.31.tgz",
+      "integrity": "sha512-Lz4BAJihoFw5nRzKvg4nawXPzutkv7wmfQ5121avptaSIXlDNJCUuxZxX/G+9EVidZGuO0UBlk+YjKbwRKJigg==",
       "requires": {
         "@types/sizzle": "*"
       }
     },
     "@types/lodash": {
-      "version": "4.14.118",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.118.tgz",
-      "integrity": "sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw=="
+      "version": "4.14.138",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz",
+      "integrity": "sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg=="
     },
     "@types/sizzle": {
       "version": "2.3.2",
@@ -202,9 +216,9 @@
       "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
     },
     "@types/underscore": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.9.tgz",
-      "integrity": "sha512-vfzZGgZKRFy7KEWcBGfIFk+h6B+thDCLfkD1exMBMRlUsx2icA+J6y4kAbZs/TjSTeY1duw89QUU133TSzr60Q=="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-KgOKTAD+9X+qvZnB5S1+onqKc4E+PZ+T6CM/NA5ohRPLHJXb+yCJMVf8pWOnvuBuKFNUAJW8N97IA6lba6mZGg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
@@ -406,13 +420,14 @@
       }
     },
     "ajv": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.6.tgz",
-      "integrity": "sha1-Sy8aGd7Ok9V6whYDfj6XkcfdFWQ=",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "requires": {
-        "co": "^4.6.0",
-        "json-schema-traverse": "^0.3.0",
-        "json-stable-stringify": "^1.0.1"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ajv-errors": {
@@ -554,6 +569,11 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "atob": {
       "version": "2.1.2",
@@ -977,11 +997,6 @@
         }
       }
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1018,14 +1033,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
       "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
       "dev": true
-    },
-    "comment-json": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-1.1.3.tgz",
-      "integrity": "sha1-aYbDMw/uDEyeAMI5jNYa+l2PI54=",
-      "requires": {
-        "json-parser": "^1.0.0"
-      }
     },
     "commondir": {
       "version": "1.0.1",
@@ -1442,11 +1449,6 @@
         "estraverse": "^4.1.1"
       }
     },
-    "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-    },
     "esrecurse": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
@@ -1638,14 +1640,12 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fastparse": {
       "version": "1.1.2",
@@ -2798,9 +2798,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -2820,26 +2820,10 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
-    "json-parser": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-parser/-/json-parser-1.1.5.tgz",
-      "integrity": "sha1-5i7FJh0aal/CDoEqMgdAxtkAVnc=",
-      "requires": {
-        "esprima": "^2.7.0"
-      }
-    },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json5": {
       "version": "0.5.1",
@@ -2850,7 +2834,8 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
     },
     "kind-of": {
       "version": "6.0.2",
@@ -3074,7 +3059,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mississippi": {
@@ -3134,9 +3119,9 @@
       }
     },
     "moment": {
-      "version": "2.21.0",
-      "resolved": "http://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -3195,6 +3180,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
       "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-libs-browser": {
       "version": "2.1.0",
@@ -3785,8 +3775,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -3801,9 +3790,9 @@
       "dev": true
     },
     "querystringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "randombytes": {
       "version": "2.0.6",
@@ -4794,7 +4783,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -4835,11 +4823,11 @@
       }
     },
     "url-parse": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
-      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "requires": {
-        "querystringify": "^2.0.0",
+        "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
     },
@@ -5082,6 +5070,14 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "ws": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
+      "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
+      "requires": {
+        "async-limiter": "^1.0.0"
+      }
     },
     "xregexp": {
       "version": "4.0.0",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lineup_widget",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -209,6 +209,12 @@
       "version": "4.14.138",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz",
       "integrity": "sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg=="
+    },
+    "@types/node": {
+      "version": "12.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
+      "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==",
+      "dev": true
     },
     "@types/sizzle": {
       "version": "2.3.2",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lineup_widget",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Wrapper around the LineUp.js library for multi attribute rankings",
   "keywords": [
     "jupyter",
@@ -48,6 +48,7 @@
     "lineupjs": "~3.1.7"
   },
   "devDependencies": {
+    "@types/node": "^12.7.4",
     "css-loader": "^1.0.1",
     "file-loader": "^2.0.0",
     "mkdirp": "^0.5.1",

--- a/js/package.json
+++ b/js/package.json
@@ -44,7 +44,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.2.2",
+    "@jupyter-widgets/base": "^2.0.1",
     "lineupjs": "~3.1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Simple version bump + manage version in 1 spot
<img width="767" alt="Screen Shot 2019-09-06 at 11 19 04 AM" src="https://user-images.githubusercontent.com/3105306/64439568-3982f180-d098-11e9-9761-75d0add0ef44.png">
